### PR TITLE
feat: PlaylistLoader ランタイムモジュール (Phase B3)

### DIFF
--- a/Modules/PlaylistLoader/PlaylistLoader.asset
+++ b/Modules/PlaylistLoader/PlaylistLoader.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 5
+      Data: 8
     - Name: 
       Entry: 7
       Data: 
@@ -122,25 +122,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _redirectPool
+      Data: _ui
     - Name: $v
       Entry: 7
       Data: 8|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _redirectPool
+      Data: _ui
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 9|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: VRC.SDKBase.VRCUrl[], VRCSDKBase
+      Data: Yamadev.YamaStream.Modules.PlaylistLoader.PlaylistLoaderUI, Yamadev.YamaStream.Modules.PlaylistLoader
     - Name: 
       Entry: 8
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 9
+      Data: 4
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -182,19 +182,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _poolId
+      Data: _redirectPool
     - Name: $v
       Entry: 7
       Data: 12|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _poolId
+      Data: _redirectPool
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 13|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: System.String, mscorlib
+      Data: VRC.SDKBase.VRCUrl[], VRCSDKBase
     - Name: 
       Entry: 8
       Data: 
@@ -242,19 +242,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _poolBaseUrl
+      Data: _poolId
     - Name: $v
       Entry: 7
       Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _poolBaseUrl
+      Data: _poolId
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 13
+      Entry: 7
+      Data: 17|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.String, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 13
+      Data: 17
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -269,13 +275,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 17|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 18|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 18|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 19|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -296,25 +302,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _poolSize
+      Data: _poolBaseUrl
     - Name: $v
       Entry: 7
-      Data: 19|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 20|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _poolSize
+      Data: _poolBaseUrl
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 20|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.Int32, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 17
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 20
+      Data: 17
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -339,6 +339,174 @@ MonoBehaviour:
     - Name: 
       Entry: 8
       Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _poolSize
+    - Name: $v
+      Entry: 7
+      Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _poolSize
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 24|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 26|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _isLoading
+    - Name: $v
+      Entry: 7
+      Data: 27|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _isLoading
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 28|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 28
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 29|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _pendingResolveUrl
+    - Name: $v
+      Entry: 7
+      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _pendingResolveUrl
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 31|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.SDKBase.VRCUrl, VRCSDKBase
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 31
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
     - Name: 
       Entry: 13
       Data: 

--- a/Modules/PlaylistLoader/PlaylistLoader.cs
+++ b/Modules/PlaylistLoader/PlaylistLoader.cs
@@ -1,18 +1,173 @@
 using UdonSharp;
 using UnityEngine;
+using VRC.SDK3.Data;
+using VRC.SDK3.StringLoading;
 using VRC.SDKBase;
+using VRC.Udon.Common.Interfaces;
 
 namespace Yamadev.YamaStream.Modules.PlaylistLoader
 {
   [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
   public class PlaylistLoader : YamaPlayerModule
   {
+    [SerializeField] private PlaylistLoaderUI _ui;
     [SerializeField] private VRCUrl[] _redirectPool = new VRCUrl[0];
     [SerializeField] private string _poolId;
     [SerializeField] private string _poolBaseUrl = "https://api.example.com";
     [SerializeField] private int _poolSize = 100000;
 
+    private bool _isLoading;
+    private VRCUrl _pendingResolveUrl;
+
     public VRCUrl[] RedirectPool => _redirectPool;
     public string PoolId => _poolId;
+    public bool IsLoading => _isLoading;
+
+    public void LoadPlaylistFromUrl(VRCUrl resolveUrl)
+    {
+      if (_isLoading)
+      {
+        PrintWarning("Already loading a playlist.");
+        return;
+      }
+
+      _isLoading = true;
+      _pendingResolveUrl = resolveUrl;
+      if (Utilities.IsValid(_ui)) _ui.ShowLoading("Loading playlist...");
+      VRCStringDownloader.LoadUrl(resolveUrl, (IUdonEventReceiver)this);
+      PrintLog($"Downloading playlist from {resolveUrl.Get()}...");
+    }
+
+    public override void OnStringLoadSuccess(IVRCStringDownload result)
+    {
+      if (!Utilities.IsValid(_pendingResolveUrl) ||
+          result.Url.Get() != _pendingResolveUrl.Get())
+        return;
+
+      _isLoading = false;
+
+      if (!VRCJson.TryDeserializeFromJson(result.Result, out DataToken root)
+          || root.TokenType != TokenType.DataDictionary)
+      {
+        PrintError("Failed to parse playlist response.");
+        if (Utilities.IsValid(_ui)) _ui.ShowError("Failed to parse playlist response.");
+        return;
+      }
+
+      var rootDict = root.DataDictionary;
+
+      // "ok" チェック
+      if (rootDict.TryGetValue("ok", out DataToken okToken)
+          && okToken.TokenType == TokenType.Boolean
+          && !okToken.Boolean)
+      {
+        string error = "Playlist server returned an error.";
+        if (rootDict.TryGetValue("error", out DataToken errToken)
+            && errToken.TokenType == TokenType.String)
+          error = errToken.String;
+        PrintError(error);
+        if (Utilities.IsValid(_ui)) _ui.ShowError(error);
+        return;
+      }
+
+      // "tracks" 配列を取得
+      if (!rootDict.TryGetValue("tracks", out DataToken tracksToken)
+          || tracksToken.TokenType != TokenType.DataList
+          || tracksToken.DataList.Count == 0)
+      {
+        PrintWarning("No tracks found in playlist.");
+        if (Utilities.IsValid(_ui)) _ui.ShowError("No tracks found in playlist.");
+        return;
+      }
+
+      EnqueueFromIndexes(tracksToken.DataList);
+    }
+
+    public override void OnStringLoadError(IVRCStringDownload result)
+    {
+      if (!Utilities.IsValid(_pendingResolveUrl) ||
+          result.Url.Get() != _pendingResolveUrl.Get())
+        return;
+
+      _isLoading = false;
+      PrintError($"Failed to download playlist: {result.Error}");
+      if (Utilities.IsValid(_ui)) _ui.ShowError("Playlist server is unavailable.");
+    }
+
+    private void EnqueueFromIndexes(DataList trackDicts)
+    {
+      var queue = _controller.Queue;
+      if (!Utilities.IsValid(queue))
+      {
+        PrintError("Queue is not available.");
+        if (Utilities.IsValid(_ui)) _ui.ShowError("Queue is not available.");
+        return;
+      }
+
+      int totalCount = trackDicts.Count;
+      object[][] tempTracks = new object[totalCount][];
+      int addedCount = 0;
+      int failedCount = 0;
+
+      for (int i = 0; i < totalCount; i++)
+      {
+        if (trackDicts[i].TokenType != TokenType.DataDictionary)
+        {
+          failedCount++;
+          continue;
+        }
+        var dict = trackDicts[i].DataDictionary;
+
+        int index = TryGetInt(dict, "index", -1);
+        if (index < 0 || index >= _redirectPool.Length)
+        {
+          failedCount++;
+          continue;
+        }
+
+        int mode = TryGetInt(dict, "mode", 0);
+        string title = "";
+        if (dict.TryGetValue("title", out DataToken t)
+            && t.TokenType == TokenType.String)
+          title = t.String;
+
+        VRCUrl redirectUrl = _redirectPool[index];
+        tempTracks[addedCount] = TrackUtils.NewTrack(
+            (VideoPlayerType)mode, title, redirectUrl);
+        addedCount++;
+      }
+
+      if (addedCount == 0)
+      {
+        string msg = failedCount > 0
+            ? $"No tracks could be added ({failedCount} skipped)"
+            : "No valid tracks to add.";
+        PrintWarning(msg);
+        if (Utilities.IsValid(_ui)) _ui.ShowError(msg);
+        return;
+      }
+
+      object[][] finalTracks = new object[addedCount][];
+      for (int i = 0; i < addedCount; i++) finalTracks[i] = tempTracks[i];
+
+      _controller.TakeOwnership();
+      queue.AddTracks(finalTracks);
+
+      var message = failedCount > 0
+          ? $"Added {addedCount}/{totalCount} tracks ({failedCount} failed)"
+          : $"Added {addedCount} tracks to queue";
+      PrintLog(message);
+      if (Utilities.IsValid(_ui)) _ui.ShowSuccess(message);
+    }
+
+    private int TryGetInt(DataDictionary dict, string key, int defaultValue)
+    {
+      if (!dict.TryGetValue(key, out DataToken token)) return defaultValue;
+      if (token.TokenType == TokenType.Double) return (int)token.Double;
+      if (token.TokenType == TokenType.Float) return (int)token.Float;
+      if (token.TokenType == TokenType.Int) return token.Int;
+      if (token.TokenType == TokenType.Long) return (int)token.Long;
+      return defaultValue;
+    }
   }
 }

--- a/Modules/PlaylistLoader/PlaylistLoaderUI.cs
+++ b/Modules/PlaylistLoader/PlaylistLoaderUI.cs
@@ -1,0 +1,49 @@
+using UdonSharp;
+using UnityEngine;
+using UnityEngine.UI;
+using VRC.SDK3.Components;
+using VRC.SDKBase;
+
+namespace Yamadev.YamaStream.Modules.PlaylistLoader
+{
+  [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+  public class PlaylistLoaderUI : YamaPlayerListener
+  {
+    [SerializeField] private PlaylistLoader _loader;
+    [SerializeField] private VRCUrlInputField _playlistUrlInput;
+    [SerializeField] private Text _statusText;
+    [SerializeField] private GameObject _loadingIndicator;
+
+    public void OnPlaylistUrlSubmit()
+    {
+      if (!Utilities.IsValid(_playlistUrlInput) || !Utilities.IsValid(_loader)) return;
+      var url = _playlistUrlInput.GetUrl();
+      _playlistUrlInput.SetUrl(VRCUrl.Empty);
+      _loader.LoadPlaylistFromUrl(url);
+    }
+
+    public void ShowLoading(string message)
+    {
+      if (Utilities.IsValid(_loadingIndicator)) _loadingIndicator.SetActive(true);
+      if (Utilities.IsValid(_statusText)) _statusText.text = message;
+    }
+
+    public void ShowSuccess(string message)
+    {
+      if (Utilities.IsValid(_loadingIndicator)) _loadingIndicator.SetActive(false);
+      if (Utilities.IsValid(_statusText)) _statusText.text = message;
+      SendCustomEventDelayedSeconds(nameof(ClearStatus), 5f);
+    }
+
+    public void ShowError(string message)
+    {
+      if (Utilities.IsValid(_loadingIndicator)) _loadingIndicator.SetActive(false);
+      if (Utilities.IsValid(_statusText)) _statusText.text = message;
+    }
+
+    public void ClearStatus()
+    {
+      if (Utilities.IsValid(_statusText)) _statusText.text = "";
+    }
+  }
+}

--- a/Modules/PlaylistLoader/PlaylistLoaderUI.cs
+++ b/Modules/PlaylistLoader/PlaylistLoaderUI.cs
@@ -10,9 +10,12 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
   public class PlaylistLoaderUI : YamaPlayerListener
   {
     [SerializeField] private PlaylistLoader _loader;
-    [SerializeField] private VRCUrlInputField _playlistUrlInput;
+    [SerializeField, RegisterEvent(nameof(VRCUrlInputField.onEndEdit), nameof(OnPlaylistUrlSubmit))]
+    private VRCUrlInputField _playlistUrlInput;
     [SerializeField] private Text _statusText;
     [SerializeField] private GameObject _loadingIndicator;
+
+    private bool _clearPending;
 
     public void OnPlaylistUrlSubmit()
     {
@@ -24,25 +27,31 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
 
     public void ShowLoading(string message)
     {
+      _clearPending = false;
       if (Utilities.IsValid(_loadingIndicator)) _loadingIndicator.SetActive(true);
       if (Utilities.IsValid(_statusText)) _statusText.text = message;
     }
 
     public void ShowSuccess(string message)
     {
+      _clearPending = false;
       if (Utilities.IsValid(_loadingIndicator)) _loadingIndicator.SetActive(false);
       if (Utilities.IsValid(_statusText)) _statusText.text = message;
+      _clearPending = true;
       SendCustomEventDelayedSeconds(nameof(ClearStatus), 5f);
     }
 
     public void ShowError(string message)
     {
+      _clearPending = false;
       if (Utilities.IsValid(_loadingIndicator)) _loadingIndicator.SetActive(false);
       if (Utilities.IsValid(_statusText)) _statusText.text = message;
     }
 
     public void ClearStatus()
     {
+      if (!_clearPending) return;
+      _clearPending = false;
       if (Utilities.IsValid(_statusText)) _statusText.text = "";
     }
   }

--- a/Modules/PlaylistLoader/PlaylistLoaderUI.cs.meta
+++ b/Modules/PlaylistLoader/PlaylistLoaderUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0019592de4ad5ba46a95861c0b7adee7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/PlaylistLoader/Yamadev.YamaStream.Modules.PlaylistLoader.asmdef
+++ b/Modules/PlaylistLoader/Yamadev.YamaStream.Modules.PlaylistLoader.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:99835874ee819da44948776e0df4ff1d",
-        "GUID:befb3e42bf02a9b488522ef543d61aa0"
+        "GUID:befb3e42bf02a9b488522ef543d61aa0",
+        "GUID:f70a94b0bedfa8ec50ed757f72032810"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Summary

- PlaylistLoader のランタイムロジックを実装
- PlaylistLoaderUI (専用 UI コンポーネント) を新規作成
- Resolve API からの index 付き JSON を取得し、VRCUrl Pool 経由で Queue にトラックを一括追加

## 変更内容

### PlaylistLoader.cs (既存スタブを拡張)
- `LoadPlaylistFromUrl(VRCUrl)` — VRCStringDownloader で Resolve API を呼ぶ
- `OnStringLoadSuccess` — VRCJson パース、ok チェック、tracks 抽出
- `OnStringLoadError` — エラー UI 表示
- `EnqueueFromIndexes` — index → `_redirectPool[index]` → TrackUtils.NewTrack → Queue.AddTracks
- `TryGetInt` — VRCJson の数値型変換ヘルパー
- 部分成功対応 ("Added 8/12 tracks (4 failed)")
- `_controller.TakeOwnership()` → `AddTracks()` の順序保証

### PlaylistLoaderUI.cs (新規)
- `VRCUrlInputField` で resolve URL を入力 (`RegisterEvent` でイベントバインド)
- ShowLoading / ShowSuccess / ShowError ステータス表示
- 成功時 5 秒後に自動クリア (連続操作時のキャンセルフラグ付き)

### asmdef
- OdinSerializer 参照を追加 (VRC.SDK3.Data 使用のため)

## Test plan

- [x] UdonSharp コンパイル成功 (37 scripts, no errors)
- [ ] Resolve API モック JSON でのパース動作確認 (サーバー未実装のため E2E は #6)

## Note

本 PR は #5 のランタイムロジック先行実装です。prefab 作成と Module Manager 統合は別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)