### PR TITLE
fix: PlaylistLoader Inspector に Controller フィールドを表示

### DIFF
--- a/Modules/PlaylistLoader/Editor/PlaylistLoaderEditor.cs
+++ b/Modules/PlaylistLoader/Editor/PlaylistLoaderEditor.cs
@@ -10,6 +10,7 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
   [CustomEditor(typeof(PlaylistLoader))]
   public class PlaylistLoaderEditor : EditorBase
   {
+    private SerializedProperty _controller;
     private SerializedProperty _redirectPool;
     private SerializedProperty _poolId;
     private SerializedProperty _poolBaseUrl;
@@ -20,6 +21,7 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       ShowHeader = false;
       Title = "Playlist Loader";
 
+      _controller = serializedObject.FindProperty("_controller");
       _redirectPool = serializedObject.FindProperty("_redirectPool");
       _poolId = serializedObject.FindProperty("_poolId");
       _poolBaseUrl = serializedObject.FindProperty("_poolBaseUrl");
@@ -31,6 +33,8 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       base.OnInspectorGUI();
       serializedObject.Update();
 
+      EditorGUILayout.PropertyField(_controller, new GUIContent("Controller"));
+      EditorGUILayout.Space(SpaceMedium);
       DrawPoolSettings();
       EditorGUILayout.Space(SpaceMedium);
       DrawPoolStatus();


### PR DESCRIPTION
## Summary

PlaylistLoader の Inspector に `_controller` フィールドを表示し、手動でControllerを割り当て可能にする。

## 背景

`YamaPlayerModule` 基底クラスの `_controller` は `[HideInInspector]` で隠されており、通常は Module Manager が自動設定する。しかし PlaylistLoader は prefab / Module Manager 統合が未完了のため、手動設定が必要。Inspector に表示されないと Debug モードでしか設定できない。

## 変更内容

`PlaylistLoaderEditor.cs` で `_controller` を `SerializedProperty` として取得し、`EditorGUILayout.PropertyField` で表示。基底クラスへの変更なし。

## Test plan

- [ ] Inspector に Controller フィールドが表示される
- [ ] Controller を割り当ててビルド後、エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)