### PR TITLE
refactor: PlaylistLoader から ShowMessage 依存を削除 (#24)

### DIFF
--- a/Modules/PlaylistLoader/Editor/PlaylistLoaderEditor.cs
+++ b/Modules/PlaylistLoader/Editor/PlaylistLoaderEditor.cs
@@ -10,7 +10,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
   public class PlaylistLoaderEditor : EditorBase
   {
     private SerializedProperty _controller;
-    private SerializedProperty _ui;
     private SerializedProperty _redirectPool;
     private SerializedProperty _poolId;
     private SerializedProperty _poolBaseUrl;
@@ -22,7 +21,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       Title = "Playlist Loader";
 
       _controller = serializedObject.FindProperty("_controller");
-      _ui = serializedObject.FindProperty("_ui");
       _redirectPool = serializedObject.FindProperty("_redirectPool");
       _poolId = serializedObject.FindProperty("_poolId");
       _poolBaseUrl = serializedObject.FindProperty("_poolBaseUrl");
@@ -53,10 +51,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       EditorGUILayout.PropertyField(_controller, new GUIContent("Controller"));
       if (_controller.objectReferenceValue == null)
         EditorGUILayout.HelpBox("Controller が未設定です。YamaPlayer の Controller を割り当ててください。", MessageType.Error);
-
-      EditorGUILayout.PropertyField(_ui, new GUIContent("UI (PlaylistLoaderUI)"));
-      if (_ui.objectReferenceValue == null)
-        EditorGUILayout.HelpBox("UI が未設定です。PlaylistLoaderUI を割り当ててください。", MessageType.Error);
     }
 
     private void DrawPoolSettings()

--- a/Modules/PlaylistLoader/PlaylistLoader.asset
+++ b/Modules/PlaylistLoader/PlaylistLoader.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: PlaylistLoader
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: e5f2114b73ced9846951858ae3cf67df,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 4a4e2a0556ece41459e3aab04e95a6c8,
     type: 2}
   udonAssembly: 
   assemblyError: 
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 8
+      Data: 7
     - Name: 
       Entry: 7
       Data: 
@@ -122,25 +122,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _ui
+      Data: _redirectPool
     - Name: $v
       Entry: 7
       Data: 8|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _ui
+      Data: _redirectPool
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 9|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: Yamadev.YamaStream.Modules.PlaylistLoader.PlaylistLoaderUI, Yamadev.YamaStream.Modules.PlaylistLoader
+      Data: VRC.SDKBase.VRCUrl[], VRCSDKBase
     - Name: 
       Entry: 8
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 4
+      Data: 9
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -182,19 +182,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _redirectPool
+      Data: _poolId
     - Name: $v
       Entry: 7
       Data: 12|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _redirectPool
+      Data: _poolId
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 13|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: VRC.SDKBase.VRCUrl[], VRCSDKBase
+      Data: System.String, mscorlib
     - Name: 
       Entry: 8
       Data: 
@@ -242,25 +242,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _poolId
+      Data: _poolBaseUrl
     - Name: $v
       Entry: 7
       Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _poolId
+      Data: _poolBaseUrl
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 17|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.String, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 13
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 17
+      Data: 13
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -275,13 +269,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 18|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 17|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 19|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 18|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -302,19 +296,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _poolBaseUrl
+      Data: _poolSize
     - Name: $v
       Entry: 7
-      Data: 20|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 19|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _poolBaseUrl
+      Data: _poolSize
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 17
+      Entry: 7
+      Data: 20|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 17
+      Data: 20
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -356,19 +356,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _poolSize
+      Data: _isLoading
     - Name: $v
       Entry: 7
       Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _poolSize
+      Data: _isLoading
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 24|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: System.Int32, mscorlib
+      Data: System.Boolean, mscorlib
     - Name: 
       Entry: 8
       Data: 
@@ -386,70 +386,10 @@ MonoBehaviour:
       Data: 
     - Name: <IsSerialized>k__BackingField
       Entry: 5
-      Data: true
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 26|UnityEngine.SerializeField, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _isLoading
-    - Name: $v
-      Entry: 7
-      Data: 27|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: _isLoading
-    - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 28|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.Boolean, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 28
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 29|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -473,13 +413,13 @@ MonoBehaviour:
       Data: _pendingResolveUrl
     - Name: $v
       Entry: 7
-      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 26|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _pendingResolveUrl
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 31|System.RuntimeType, mscorlib
+      Data: 27|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: VRC.SDKBase.VRCUrl, VRCSDKBase
@@ -488,7 +428,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 31
+      Data: 27
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -503,7 +443,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Modules/PlaylistLoader/PlaylistLoader.cs
+++ b/Modules/PlaylistLoader/PlaylistLoader.cs
@@ -10,7 +10,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
   [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
   public class PlaylistLoader : YamaPlayerModule
   {
-    [SerializeField] private PlaylistLoaderUI _ui;
     [SerializeField] private VRCUrl[] _redirectPool = new VRCUrl[0];
     [SerializeField] private string _poolId = "default";
     [SerializeField] private string _poolBaseUrl = "https://playlist.vrc-hub.com";
@@ -61,7 +60,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
 
       _isLoading = false;
       PrintError($"Failed to download playlist: {result.Error}");
-      NotifyUI("Playlist server is unavailable.");
     }
 
     private bool TryParseResponse(string json, out DataList tracks)
@@ -72,7 +70,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
           || root.TokenType != TokenType.DataDictionary)
       {
         PrintError("Failed to parse playlist response.");
-        NotifyUI("Failed to parse playlist response.");
         return false;
       }
 
@@ -87,7 +84,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
             && errToken.TokenType == TokenType.String)
           error = errToken.String;
         PrintError(error);
-        NotifyUI(error);
         return false;
       }
 
@@ -96,7 +92,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
           || tracksToken.DataList.Count == 0)
       {
         PrintWarning("No tracks found in playlist.");
-        NotifyUI("No tracks found in playlist.");
         return false;
       }
 
@@ -144,7 +139,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
             ? $"No tracks could be added ({failedCount} skipped)"
             : "No valid tracks to add.";
         PrintWarning(msg);
-        NotifyUI(msg);
         return null;
       }
 
@@ -159,7 +153,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
       if (!Utilities.IsValid(queue))
       {
         PrintError("Queue is not available.");
-        NotifyUI("Queue is not available.");
         return;
       }
 
@@ -179,12 +172,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
           ? $"Added {tracks.Length}/{totalCount} tracks ({failedCount} failed)"
           : $"Added {tracks.Length} tracks to queue";
       PrintLog(message);
-      NotifyUI(message);
-    }
-
-    private void NotifyUI(string message)
-    {
-      if (Utilities.IsValid(_ui)) _ui.ShowNotification(message);
     }
 
     private int TryGetInt(DataDictionary dict, string key, int defaultValue)

--- a/Modules/PlaylistLoader/PlaylistLoaderUI.asset
+++ b/Modules/PlaylistLoader/PlaylistLoaderUI.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: PlaylistLoaderUI
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: 4fcc83a3e555d6c408f6c5d697265403,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: f416cbf52607bfb48b8adf892a55c3a8,
     type: 2}
   udonAssembly: 
   assemblyError: 
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 2
     - Name: 
       Entry: 7
       Data: 
@@ -159,60 +159,6 @@ MonoBehaviour:
     - Name: 
       Entry: 8
       Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _uiController
-    - Name: $v
-      Entry: 7
-      Data: 11|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: _uiController
-    - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 12|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: Yamadev.YamaStream.UI.UIController, Yamadev.YamaStream.Runtime
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 4
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: false
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 13|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
     - Name: 
       Entry: 13
       Data: 

--- a/Modules/PlaylistLoader/PlaylistLoaderUI.cs
+++ b/Modules/PlaylistLoader/PlaylistLoaderUI.cs
@@ -2,7 +2,6 @@ using UdonSharp;
 using UnityEngine;
 using VRC.SDK3.Components;
 using VRC.SDKBase;
-using Yamadev.YamaStream.UI;
 
 namespace Yamadev.YamaStream.Modules.PlaylistLoader
 {
@@ -13,13 +12,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
     [SerializeField, RegisterEvent(nameof(VRCUrlInputField.onEndEdit), nameof(OnPlaylistUrlSubmit))]
     private VRCUrlInputField _playlistUrlInput;
 
-    private UIController _uiController;
-
-    private void Start()
-    {
-      _uiController = GetComponentInParent<UIController>();
-    }
-
     public void OnPlaylistUrlSubmit()
     {
       if (!Utilities.IsValid(_playlistUrlInput) || !Utilities.IsValid(_loader)) return;
@@ -28,12 +20,6 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
       if (!Utilities.IsValid(url) || string.IsNullOrEmpty(url.Get())) return;
       _playlistUrlInput.SetUrl(VRCUrl.Empty);
       _loader.LoadPlaylistFromUrl(url);
-    }
-
-    public void ShowNotification(string message)
-    {
-      if (!Utilities.IsValid(_uiController)) return;
-      _uiController.ShowMessage("Playlist Loader", message);
     }
   }
 }

--- a/docs/design/url-pool-unity.md
+++ b/docs/design/url-pool-unity.md
@@ -44,9 +44,10 @@ Modules/
 [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 public class PlaylistLoader : YamaPlayerModule
 {
-    [SerializeField] private PlaylistLoaderUI _ui;
     [SerializeField] private VRCUrl[] _redirectPool = new VRCUrl[0];
-    [SerializeField] private string _poolId;
+    [SerializeField] private string _poolId = "default";
+    [SerializeField] private string _poolBaseUrl = "https://playlist.vrc-hub.com";
+    [SerializeField] private int _poolSize = 100000;
 
     private bool _isLoading;
     private VRCUrl _pendingResolveUrl;
@@ -61,10 +62,10 @@ public class PlaylistLoaderUI : YamaPlayerListener
 {
     [SerializeField] private PlaylistLoader _loader;
     [SerializeField] private VRCUrlInputField _playlistUrlInput;
-    [SerializeField] private Text _statusText;
-    [SerializeField] private GameObject _loadingIndicator;
 }
 ```
+
+PlaylistLoaderUI は URL 入力の受け渡しのみに特化。成功/エラー通知はログ出力 (`PrintLog` / `PrintError`) のみ。
 
 ### Editor 用設定
 
@@ -183,28 +184,31 @@ var track = TrackUtils.NewTrack((VideoPlayerType)mode, title, redirectUrl);
 
 ## エラー処理
 
-| 失敗ケース | UI メッセージ例 |
-|-----------|----------------|
-| resolve URL ダウンロード失敗 | `Playlist server is unavailable` |
-| JSON パース失敗 | `Failed to parse playlist response` |
-| `index` フィールド欠落 | `Invalid track data (missing index)` |
-| index が pool 範囲外 | `Pool index out of range` |
-| オーナーシップ不足 | (TakeOwnership で自動取得) |
-| 0 件追加 | `No tracks found in playlist` |
-| 一部失敗 | `Added 8/12 tracks (4 failed)` |
+エラーはログ出力 (`PrintError` / `PrintWarning`) のみ。UI ダイアログは表示しない。
+
+| 失敗ケース | ログ出力 | ユーザーの見え方 |
+|-----------|---------|----------------|
+| resolve URL ダウンロード失敗 | `PrintError("Failed to download playlist: ...")` | 何も起きない |
+| JSON パース失敗 | `PrintError("Failed to parse playlist response.")` | 何も起きない |
+| サーバーエラー (ok: false) | `PrintError(error)` | 何も起きない |
+| トラック 0 件 | `PrintWarning("No tracks found in playlist.")` | 何も起きない |
+| 一部失敗 | `PrintLog("Added 3/5 tracks (2 failed)")` | Queue に部分追加 |
+| 成功 | `PrintLog("Added 5 tracks to queue")` | Queue に追加 + 自動再生 |
 
 ---
 
 ## 擬似コード
 
 ```csharp
+// --- PlaylistLoader.cs ---
+
 public void LoadPlaylistFromUrl(VRCUrl resolveUrl)
 {
     if (_isLoading) return;
     _isLoading = true;
     _pendingResolveUrl = resolveUrl;
-    if (Utilities.IsValid(_ui)) _ui.ShowLoading("Loading playlist...");
     VRCStringDownloader.LoadUrl(resolveUrl, (IUdonEventReceiver)this);
+    PrintLog($"Downloading playlist from {resolveUrl.Get()}...");
 }
 
 public override void OnStringLoadSuccess(IVRCStringDownload result)
@@ -212,114 +216,49 @@ public override void OnStringLoadSuccess(IVRCStringDownload result)
     if (result.Url.Get() != _pendingResolveUrl.Get()) return;
     _isLoading = false;
 
-    // JSON パース
-    if (!VRCJson.TryDeserializeFromJson(result.Result, out DataToken root)
-        || root.TokenType != TokenType.DataDictionary)
-    {
-        if (Utilities.IsValid(_ui)) _ui.ShowError("Failed to parse playlist response.");
-        return;
-    }
-
-    var rootDict = root.DataDictionary;
-
-    // "ok" チェック
-    if (rootDict.TryGetValue("ok", out DataToken okToken)
-        && okToken.TokenType == TokenType.Boolean
-        && !okToken.Boolean)
-    {
-        string error = "Playlist server returned an error.";
-        if (rootDict.TryGetValue("error", out DataToken errToken)
-            && errToken.TokenType == TokenType.String)
-            error = errToken.String;
-        if (Utilities.IsValid(_ui)) _ui.ShowError(error);
-        return;
-    }
-
-    // "tracks" 配列を取得
-    if (!rootDict.TryGetValue("tracks", out DataToken tracksToken)
-        || tracksToken.TokenType != TokenType.DataList
-        || tracksToken.DataList.Count == 0)
-    {
-        if (Utilities.IsValid(_ui)) _ui.ShowError("No tracks found in playlist.");
-        return;
-    }
-
-    // index → VRCUrl → Track → Queue
-    EnqueueFromIndexes(tracksToken.DataList);
+    if (!TryParseResponse(result.Result, out DataList tracks)) return;
+    var builtTracks = BuildTracks(tracks, out int failedCount);
+    if (builtTracks == null) return;
+    EnqueueAndPlay(builtTracks, tracks.Count, failedCount);
 }
 
 public override void OnStringLoadError(IVRCStringDownload result)
 {
     if (result.Url.Get() != _pendingResolveUrl.Get()) return;
     _isLoading = false;
-    if (Utilities.IsValid(_ui)) _ui.ShowError("Playlist server is unavailable.");
+    PrintError($"Failed to download playlist: {result.Error}");
 }
 
-private void EnqueueFromIndexes(DataList trackDicts)
+// TryParseResponse: JSON パース + ok チェック + tracks 抽出
+// BuildTracks: DataList → object[][] 変換 (pool 範囲外はスキップ)
+// EnqueueAndPlay: Queue 追加 + 停止中なら自動再生
+
+private void EnqueueAndPlay(object[][] tracks, int totalCount, int failedCount)
 {
-    int totalCount = trackDicts.Count;
-
-    // UdonSharp ではカスタム DTO 配列を使わず DataDictionary を直接処理
-    object[][] tempTracks = new object[totalCount][];
-    int addedCount = 0;
-    int failedCount = 0;
-
-    for (int i = 0; i < totalCount; i++)
-    {
-        if (trackDicts[i].TokenType != TokenType.DataDictionary)
-        {
-            failedCount++;
-            continue;
-        }
-        var dict = trackDicts[i].DataDictionary;
-
-        // index (必須)
-        int index = TryGetInt(dict, "index", -1);
-        if (index < 0 || index >= _redirectPool.Length)
-        {
-            failedCount++;
-            continue;
-        }
-
-        int mode = TryGetInt(dict, "mode", 0);
-        string title = "";
-        if (dict.TryGetValue("title", out DataToken t)
-            && t.TokenType == TokenType.String)
-            title = t.String;
-
-        VRCUrl redirectUrl = _redirectPool[index];
-        tempTracks[addedCount] = TrackUtils.NewTrack(
-            (VideoPlayerType)mode, title, redirectUrl);
-        addedCount++;
-    }
-
-    if (addedCount == 0)
-    {
-        if (Utilities.IsValid(_ui)) _ui.ShowError("No valid tracks to add.");
-        return;
-    }
-
-    // 実際のサイズに切り詰め
-    object[][] finalTracks = new object[addedCount][];
-    for (int i = 0; i < addedCount; i++) finalTracks[i] = tempTracks[i];
-
     _controller.TakeOwnership();
-    _controller.Queue.AddTracks(finalTracks);
+    _controller.Queue.AddTracks(tracks);
 
-    var message = failedCount > 0
-        ? $"Added {addedCount}/{totalCount} tracks ({failedCount} failed)"
-        : $"Added {addedCount} tracks to queue";
-    if (Utilities.IsValid(_ui)) _ui.ShowSuccess(message);
+    // 自動再生: 停止中のみ。再生中・一時停止中はキュー追加のみ
+    if (_controller.Stopped)
+    {
+        _controller.Forward();
+    }
+
+    PrintLog(failedCount > 0
+        ? $"Added {tracks.Length}/{totalCount} tracks ({failedCount} failed)"
+        : $"Added {tracks.Length} tracks to queue");
 }
 
-private int TryGetInt(DataDictionary dict, string key, int defaultValue)
+// --- PlaylistLoaderUI.cs ---
+
+public void OnPlaylistUrlSubmit()
 {
-    if (!dict.TryGetValue(key, out DataToken token)) return defaultValue;
-    if (token.TokenType == TokenType.Double) return (int)token.Double;
-    if (token.TokenType == TokenType.Float) return (int)token.Float;
-    if (token.TokenType == TokenType.Int) return token.Int;
-    if (token.TokenType == TokenType.Long) return (int)token.Long;
-    return defaultValue;
+    if (!Utilities.IsValid(_playlistUrlInput) || !Utilities.IsValid(_loader)) return;
+    if (_loader.IsLoading) return;
+    var url = _playlistUrlInput.GetUrl();
+    if (!Utilities.IsValid(url) || string.IsNullOrEmpty(url.Get())) return;
+    _playlistUrlInput.SetUrl(VRCUrl.Empty);
+    _loader.LoadPlaylistFromUrl(url);
 }
 ```
 


### PR DESCRIPTION
## Summary

PlaylistLoaderUI の UIController.ShowMessage() 依存を削除し、ログ出力のみに簡素化。

## 背景

VRChat E2E テスト (#21) で ShowMessage ダイアログが表示されないことを確認。エラー時に「何も起きない」挙動の方がシンプルで適切。

## 変更内容

### PlaylistLoaderUI.cs
- `_uiController` / `Start()` / `ShowNotification()` を削除
- `using Yamadev.YamaStream.UI` を削除
- UI コンポーネントは URL 入力の受け渡しのみに特化

### PlaylistLoader.cs
- `_ui` フィールドを削除（参照先がなくなったため）
- `NotifyUI()` ヘルパーと全呼び出しを削除
- 成功/エラーは `PrintLog()` / `PrintError()` のみ

### PlaylistLoaderEditor.cs
- `_ui` SerializedProperty / Inspector フィールド / null warning を削除

## Test plan
- [ ] Unity コンパイル確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)