### PR TITLE
chore: パッケージ名を com.vhub.kawaplayer に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  packageName: "net.kwxxw.yama-stream"
+  packageName: "com.vhub.kawaplayer"
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-YamaPlayer is a VRChat video player built with UdonSharp. It runs inside VRChat worlds as a networked, synced video player supporting YouTube, Twitch, and other sources. Package name: `net.kwxxw.yama-stream`, distributed via VPM (VRChat Package Manager).
+KawaPlayer is a VRChat video player (YamaPlayer fork) with PlaylistLoader for loading playlists from playlist.vrc-hub.com. Package name: `com.vhub.kawaplayer`.
 
 - **Unity version**: 2022.3
 - **Language**: C# / UdonSharp (VRChat's Udon scripting layer)

--- a/Editor/Localization/EditorLocalization.cs
+++ b/Editor/Localization/EditorLocalization.cs
@@ -10,7 +10,7 @@ namespace Yamadev.YamaStream.Editor
 {
   public static class EditorLocalization
   {
-    private const string TranslationFolder = "Packages/net.kwxxw.yama-stream/Assets/Localization/Editor";
+    private const string TranslationFolder = "Packages/com.vhub.kawaplayer/Assets/Localization/Editor";
     private const string LanguageKey = "YamaPlayer_EditorLanguage";
     private const string DefaultLanguage = "en";
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ YamaPlayer は VRChat で使うことを想定して作られた動画プレイ�
 ```json
 {
   "dependencies": {
-    "net.kwxxw.yama-stream": "file:<KawaPlayerリポジトリのパス>",
+    "com.vhub.kawaplayer": "file:<KawaPlayerリポジトリのパス>",
     ...
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "net.kwxxw.yama-stream",
+  "name": "com.vhub.kawaplayer",
   "displayName": "KawaPlayer",
   "version": "2.0.0-beta.4",
   "unity": "2022.3",
-  "description": "Video player for VRChat.",
+  "description": "VRChat video player with playlist loading via playlist.vrc-hub.com. Fork of YamaPlayer.",
   "author": {
-    "name": "kwxxw",
-    "url": "https://yamadev.booth.pm"
+    "name": "vhub",
+    "url": "https://playlist.vrc-hub.com"
   },
   "legacyFolders": {
     "Assets\\Yamadev\\YamaStream": "af99c59180c62fb41ab655b73f426e61"


### PR DESCRIPTION
## Summary

パッケージ名を `net.kwxxw.yama-stream` → `com.vhub.kawaplayer` に変更。本家 YamaPlayer との VPM 衝突を防止し、KawaPlayer を独立パッケージとして確立。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `package.json` | name, description, author を更新 |
| `Editor/Localization/EditorLocalization.cs` | 翻訳ファイルパスを `Packages/com.vhub.kawaplayer/` に変更 |
| `CLAUDE.md` | パッケージ名と説明を更新 |
| `README.md` | manifest.json の例を更新 |

## 影響

- テストプロジェクトの `manifest.json` で参照名を `com.vhub.kawaplayer` に更新する必要あり
- 既存の `net.kwxxw.yama-stream` 参照は無効になる

## Test plan

- [ ] テストプロジェクトの manifest.json を更新して Unity コンパイル確認
- [ ] EditorLocalization の翻訳ファイル読み込みが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)