### PR TITLE
fix: Queue 再生時にシャッフルを適用する

### DIFF
--- a/Runtime/Internal/Controller.Playlist.cs
+++ b/Runtime/Internal/Controller.Playlist.cs
@@ -79,10 +79,12 @@ namespace Yamadev.YamaStream
     {
       if (!Utilities.IsValid(_queue) || _queue.TrackCount == 0) return;
 
-      var track = _queue.GetTrack(0);
+      int index = _shuffle ? GetRandomIndex(_queue.TrackCount) : 0;
+
+      var track = _queue.GetTrack(index);
       PlayTrack(track);
 
-      _queue.RemoveTrack(0);
+      _queue.RemoveTrack(index);
     }
 
     public void PlayTrackFromHistory(int index)


### PR DESCRIPTION
## Summary

- `PlayTrackFromQueue()` が常に index 0（FIFO）で再生していたのを、`_shuffle` 有効時はランダム index から再生するよう修正
- PlaylistLoader 経由で Queue に追加されたトラックでもシャッフル再生が効くようになる

## 変更箇所

`Runtime/Internal/Controller.Playlist.cs` の `PlayTrackFromQueue()` のみ（+4行 / -2行）

## 動作

| 条件 | Before | After |
|------|--------|-------|
| shuffle OFF + Queue | FIFO (index 0) | FIFO (index 0) — 変更なし |
| shuffle ON + Queue | FIFO (index 0) ❌ | ランダム index ✓ |

## Test plan

- [ ] Unity C# / UdonSharp コンパイル確認
- [ ] shuffle ON: Queue からランダム順にトラックが消費されること
- [ ] shuffle OFF: 従来どおり FIFO
- [ ] PlaylistLoader 経由・手動 AddTrack 両方で同じ挙動

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)