### PR TITLE
chore: KawaPlayer バージョン設定 & GitHub Releases 配布準備

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,10 @@ jobs:
             ${{ env.unityPackage }}
             Packages/${{ env.packageName }}/package.json
 
-      - name: Build Listing
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.PAT }}
-          repository: koorimizuw/vpm-repos
-          event-type: build-listing
+      # TODO: KawaPlayer 用 VPM リポジトリ作成後に有効化する
+      # - name: Build Listing
+      #   uses: peter-evans/repository-dispatch@v3
+      #   with:
+      #     token: ${{ secrets.PAT }}
+      #     repository: Mega-Gorilla/vpm-repos
+      #     event-type: build-listing

--- a/README.md
+++ b/README.md
@@ -32,18 +32,11 @@ YamaPlayer は VRChat で使うことを想定して作られた動画プレイ�
 
 ## 導入手順
 
-このフォークは VPM 配布していません。Unity プロジェクトの `Packages/manifest.json` にローカルパッケージ参照を追加してください。
+[GitHub Releases](https://github.com/Mega-Gorilla/KawaPlayer/releases) から最新の `.unitypackage` をダウンロードし、Unity プロジェクトにインポートしてください。
 
-```json
-{
-  "dependencies": {
-    "com.vhub.kawaplayer": "file:<KawaPlayerリポジトリのパス>",
-    ...
-  }
-}
-```
-
-VRChat Worlds SDK (>=3.8.1) が導入済みのプロジェクトが必要です。
+1. VRChat Worlds SDK (>=3.8.1) が導入済みの Unity プロジェクトを用意
+2. [Releases ページ](https://github.com/Mega-Gorilla/KawaPlayer/releases) から `com.vhub.kawaplayer-x.x.x.unitypackage` をダウンロード
+3. Unity メニュー: **Assets > Import Package > Custom Package** で `.unitypackage` をインポート
 
 ## PlaylistLoader のセットアップ
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.vhub.kawaplayer",
   "displayName": "KawaPlayer",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.4-kawa.1",
   "unity": "2022.3",
   "description": "VRChat video player with playlist loading via playlist.vrc-hub.com. Fork of YamaPlayer.",
   "author": {


### PR DESCRIPTION
## Summary

- `package.json` のバージョンを `2.0.0-beta.4-kawa.1` に設定（本家ベース + KawaPlayer リビジョン形式）
- `release.yml` の `repository-dispatch` を本家 VPM リポジトリ (`koorimizuw/vpm-repos`) からコメントアウト

## バージョン命名規則

`{本家バージョン}-kawa.{リビジョン}` 形式:
- 本家ベースバージョンが明確にわかる
- KawaPlayer 独自の修正が増えたら `kawa.2`, `kawa.3` と上げる

## 配布方針

GitHub Releases から UnityPackage をダウンロードして Unity にインポートする方式を採用。
VPM リポジトリの構築は将来の拡張とし、現時点では対応しない。
そのため release.yml の VPM dispatch ステップをコメントアウト。

## Test plan

- [ ] GitHub Actions workflow_dispatch でリリースビルドが成功する
- [ ] GitHub Releases に UnityPackage / ZIP / package.json が生成される

Refs #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)