### PR TITLE
Info画面をKawaPlayer向けに更新

### DIFF
--- a/Assets/updatelog.txt
+++ b/Assets/updatelog.txt
@@ -4,8 +4,6 @@ v2.0.0-beta.4-kawa.1
 KawaPlayerとしての初回リリース
 PlaylistLoaderモジュールを統合したプレハブを追加
 キューからのシャッフル再生が機能しない不具合を修正
-パッケージ名をcom.vhub.kawaplayerに変更
-GitHub Releasesによる配布に対応
 
 --- 以下はベース版(YamaPlayer)の更新履歴 ---
 

--- a/Assets/updatelog.txt
+++ b/Assets/updatelog.txt
@@ -1,5 +1,14 @@
 更新履歴:
 
+v2.0.0-beta.4-kawa.1
+KawaPlayerとしての初回リリース
+PlaylistLoaderモジュールを統合したプレハブを追加
+キューからのシャッフル再生が機能しない不具合を修正
+パッケージ名をcom.vhub.kawaplayerに変更
+GitHub Releasesによる配布に対応
+
+--- 以下はベース版(YamaPlayer)の更新履歴 ---
+
 v2.0.0
 画像表示機能を実装
 モジュール機能を実装

--- a/Assets/updatelog.txt
+++ b/Assets/updatelog.txt
@@ -1,3 +1,6 @@
+※VHub Playlist URLを利用するには
+Playlist.Vrc-Hub.comにてURL取得が必要です
+
 更新履歴:
 
 v2.0.0-beta.4-kawa.1

--- a/Assets/updatelog.txt
+++ b/Assets/updatelog.txt
@@ -1,6 +1,3 @@
-※VHub Playlist URLを利用するには
-Playlist.Vrc-Hub.comにてURL取得が必要です
-
 更新履歴:
 
 v2.0.0-beta.4-kawa.1

--- a/Editor/Package/PackageManager.cs
+++ b/Editor/Package/PackageManager.cs
@@ -9,8 +9,9 @@ namespace Yamadev.YamaStream.Editor
   [InitializeOnLoad]
   public static class PackageManager
   {
-    public const string VpmId = "com.vhub.kawaplayer";
-    public const string VpmUrl = "https://vpm.vrc-hub.com/index.json";
+    // TODO: KawaPlayer 用の VPM リポジトリを構築したら repo ID と URL を更新する
+    public const string VpmId = "net.kwxxw.vpm";
+    public const string VpmUrl = "https://vpm.kwxxw.net/index.json";
     private const string CheckBetaKey = "YamaPlayer_CheckBetaUpdate";
 
     public static bool HasNewVersion { get; private set; } = false;

--- a/Editor/Package/PackageManager.cs
+++ b/Editor/Package/PackageManager.cs
@@ -9,8 +9,8 @@ namespace Yamadev.YamaStream.Editor
   [InitializeOnLoad]
   public static class PackageManager
   {
-    public const string VpmId = "net.kwxxw.vpm";
-    public const string VpmUrl = "https://vpm.kwxxw.net/index.json";
+    public const string VpmId = "com.vhub.kawaplayer";
+    public const string VpmUrl = "https://vpm.vrc-hub.com/index.json";
     private const string CheckBetaKey = "YamaPlayer_CheckBetaUpdate";
 
     public static bool HasNewVersion { get; private set; } = false;

--- a/Prefabs/UI/VersionPanel.prefab
+++ b/Prefabs/UI/VersionPanel.prefab
@@ -298,6 +298,7 @@ RectTransform:
   - {fileID: 4252213422087418573}
   - {fileID: 2539601286317749361}
   - {fileID: 1651002391702483032}
+  - {fileID: 5550001000000000001}
   m_Father: {fileID: 7301027359126987278}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
@@ -1516,3 +1517,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5550000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5550001000000000001}
+  - component: {fileID: 5550002000000000001}
+  - component: {fileID: 5550003000000000001}
+  m_Layer: 0
+  m_Name: Note
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5550001000000000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5550000000000000001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.19999999, y: 0.19999999, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7095321348814293358}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -80, y: -250}
+  m_SizeDelta: {x: 2000, y: 400}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &5550002000000000001
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5550000000000000001}
+  m_CullTransparentMesh: 0
+--- !u!114 &5550003000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5550000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 2100000, guid: 35630e38b4e5ffb40b44ec5348b4333f, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.6}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6488e13b806b0524dbadc43e3a9bd5fb, type: 3}
+    m_FontSize: 90
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 180
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u203BVHub Playlist URL\u3092\u5229\u7528\u3059\u308B\u306B\u306F\nPlaylist.Vrc-Hub.com\u306B\u3066\nURL\u53D6\u5F97\u304C\u5FC5\u8981\u3067\u3059"

--- a/Prefabs/UI/VersionPanel.prefab
+++ b/Prefabs/UI/VersionPanel.prefab
@@ -340,7 +340,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1000, y: 500}
+  m_SizeDelta: {x: 1000, y: 200}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &5724827437242154285
 CanvasRenderer:
@@ -383,7 +383,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "playlist.vrc-hub.com\n<size=70>\u203BVHub Playlist URL\u3092\u5229\u7528\u3059\u308B\u306B\u306F\nPlaylist.Vrc-Hub.com\u306B\u3066\nURL\u53D6\u5F97\u304C\u5FC5\u8981\u3067\u3059</size>"
+  m_Text: "playlist.vrc-hub.com"
 --- !u!1 &1476864292460265578
 GameObject:
   m_ObjectHideFlags: 0
@@ -621,8 +621,8 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: -80, y: -200}
-  m_SizeDelta: {x: 320, y: 80}
-  m_Pivot: {x: 1, y: 1}
+  m_SizeDelta: {x: 320, y: 40}
+  m_Pivot: {x: 1, y: 0.5}
 --- !u!1 &4147547552402952215
 GameObject:
   m_ObjectHideFlags: 0

--- a/Prefabs/UI/VersionPanel.prefab
+++ b/Prefabs/UI/VersionPanel.prefab
@@ -340,7 +340,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1000, y: 200}
+  m_SizeDelta: {x: 1000, y: 500}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &5724827437242154285
 CanvasRenderer:
@@ -383,7 +383,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "playlist.vrc-hub.com"
+  m_Text: "playlist.vrc-hub.com\n<size=70>\u203BVHub Playlist URL\u3092\u5229\u7528\u3059\u308B\u306B\u306F\nPlaylist.Vrc-Hub.com\u306B\u3066\nURL\u53D6\u5F97\u304C\u5FC5\u8981\u3067\u3059</size>"
 --- !u!1 &1476864292460265578
 GameObject:
   m_ObjectHideFlags: 0
@@ -621,8 +621,8 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: -80, y: -200}
-  m_SizeDelta: {x: 320, y: 40}
-  m_Pivot: {x: 1, y: 0.5}
+  m_SizeDelta: {x: 320, y: 80}
+  m_Pivot: {x: 1, y: 1}
 --- !u!1 &4147547552402952215
 GameObject:
   m_ObjectHideFlags: 0

--- a/Prefabs/UI/VersionPanel.prefab
+++ b/Prefabs/UI/VersionPanel.prefab
@@ -78,7 +78,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: yamadev
+  m_Text: "YamaPlayer: kwxxw"
 --- !u!1 &84817492114388173
 GameObject:
   m_ObjectHideFlags: 0
@@ -264,7 +264,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u3084\u307E@kwxxw"
+  m_Text: "YamaPlayer Fork"
 --- !u!1 &966094477961822828
 GameObject:
   m_ObjectHideFlags: 0
@@ -383,7 +383,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: koorimizuw
+  m_Text: "playlist.vrc-hub.com"
 --- !u!1 &1476864292460265578
 GameObject:
   m_ObjectHideFlags: 0
@@ -528,7 +528,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4596b013515ae9044b42f7b335e36265, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 75fb6a844ee2fc346a1ad9aaa419017d, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -761,7 +761,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 595bd27b3c054c548b8d28e6609da9bb, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 75fb6a844ee2fc346a1ad9aaa419017d, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -836,7 +836,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 09e88118264954144b57d8e325ada724, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 8ef31c129a792f642980c32774eedb67, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -961,7 +961,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: kw_vrc
+  m_Text: "KawaPlayer: Mega-Gorilla"
 --- !u!1 &7010282274613747485
 GameObject:
   m_ObjectHideFlags: 0
@@ -1383,7 +1383,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8369954163215183805
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1496,8 +1496,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: 35630e38b4e5ffb40b44ec5348b4333f, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1506,7 +1506,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 75fb6a844ee2fc346a1ad9aaa419017d, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ab97ea5771096a348a20dec1cac271dd, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Prefabs/UI/VersionPanel.prefab
+++ b/Prefabs/UI/VersionPanel.prefab
@@ -621,7 +621,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: -200}
+  m_AnchoredPosition: {x: -80, y: -100}
   m_SizeDelta: {x: 320, y: 40}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!1 &4147547552402952215
@@ -694,7 +694,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: -150}
+  m_AnchoredPosition: {x: -80, y: -50}
   m_SizeDelta: {x: 320, y: 40}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!1 &5580756368438714808
@@ -881,7 +881,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: -100}
+  m_AnchoredPosition: {x: -80, y: 0}
   m_SizeDelta: {x: 320, y: 40}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!1 &6608305977450828347
@@ -1165,7 +1165,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: -50}
+  m_AnchoredPosition: {x: -80, y: 50}
   m_SizeDelta: {x: 320, y: 40}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!1 &7648778015771719355
@@ -1551,7 +1551,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: -250}
+  m_AnchoredPosition: {x: -80, y: -150}
   m_SizeDelta: {x: 2000, y: 400}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &5550002000000000001


### PR DESCRIPTION
## Summary
- Info画面（VersionPanel）の製作者情報をYamaPlayerからKawaPlayer向けに更新
- 左パネル: ソーシャルリンク（VRChat/X/Booth/GitHub）を廃止し、フォーク情報・開発者・VHub Playlist URL・注釈に差し替え
- 右パネル: 更新履歴をKawaPlayer版に更新（内部実装詳細を除外）
- PackageManager.cs: VpmId/VpmUrlをKawaPlayer向けに更新

Closes #32

## 変更後の左パネル表示
| アイコン | テキスト |
|---------|---------|
| info | YamaPlayer Fork |
| github | KawaPlayer: Mega-Gorilla |
| github | YamaPlayer: kwxxw |
| link | playlist.vrc-hub.com |
| (なし) | ※VHub Playlist URLを利用するにはPlaylist.Vrc-Hub.comにてURL取得が必要です |

## 変更ファイル
- `Prefabs/UI/VersionPanel.prefab` — 左パネルのアイコン・テキスト差し替え、製作者アバター非表示、Note要素追加、位置調整
- `Assets/updatelog.txt` — KawaPlayer版の更新履歴に更新
- `Editor/Package/PackageManager.cs` — VpmId/VpmUrl更新

## Test plan
- [x] Unity上でInfo画面を開き、左パネルの表示内容を確認
- [x] 製作者アバター画像が非表示になっていることを確認
- [x] 左パネル下部に注釈テキストが表示されることを確認
- [x] 右パネルの更新履歴にKawaPlayer版の内容が表示されることを確認
- [ ] アイコン（info, github, link）が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)