### PR TITLE
feat: PlaylistLoader に Auto Load On Start 機能を追加

### DIFF
--- a/Modules/PlaylistLoader/Editor/PlaylistLoaderEditor.cs
+++ b/Modules/PlaylistLoader/Editor/PlaylistLoaderEditor.cs
@@ -14,6 +14,9 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
     private SerializedProperty _poolId;
     private SerializedProperty _poolBaseUrl;
     private SerializedProperty _poolSize;
+    private SerializedProperty _autoLoadOnStart;
+    private SerializedProperty _autoLoadUrl;
+    private SerializedProperty _autoLoadDelay;
 
     private void OnEnable()
     {
@@ -25,6 +28,9 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       _poolId = serializedObject.FindProperty("_poolId");
       _poolBaseUrl = serializedObject.FindProperty("_poolBaseUrl");
       _poolSize = serializedObject.FindProperty("_poolSize");
+      _autoLoadOnStart = serializedObject.FindProperty("_autoLoadOnStart");
+      _autoLoadUrl = serializedObject.FindProperty("_autoLoadUrl");
+      _autoLoadDelay = serializedObject.FindProperty("_autoLoadDelay");
     }
 
     public override void OnInspectorGUI()
@@ -39,6 +45,8 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       DrawPoolStatus();
       EditorGUILayout.Space(SpaceMedium);
       DrawPoolActions();
+      EditorGUILayout.Space(SpaceMedium);
+      DrawAutoLoadSection();
 
       serializedObject.ApplyModifiedProperties();
     }
@@ -104,6 +112,27 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader.Editor
       if (GUILayout.Button("Generate Pool"))
       {
         GeneratePool();
+      }
+    }
+
+    private void DrawAutoLoadSection()
+    {
+      EditorGUILayout.LabelField("Auto Load", EditorStyles.boldLabel);
+      EditorGUILayout.Space(SpaceSmall);
+
+      EditorGUILayout.PropertyField(_autoLoadOnStart, new GUIContent("Auto Load On Start"));
+
+      if (!_autoLoadOnStart.boolValue) return;
+
+      EditorGUILayout.PropertyField(_autoLoadUrl, new GUIContent("Resolve URL"));
+      EditorGUILayout.PropertyField(_autoLoadDelay, new GUIContent("Delay (sec)"));
+
+      var urlProp = _autoLoadUrl.FindPropertyRelative("url");
+      if (urlProp != null && string.IsNullOrEmpty(urlProp.stringValue))
+      {
+        EditorGUILayout.HelpBox(
+          "Resolve URL が未設定です。playlist.vrc-hub.com の Resolve URL を入力してください。",
+          MessageType.Warning);
       }
     }
 

--- a/Modules/PlaylistLoader/PlaylistLoader.cs
+++ b/Modules/PlaylistLoader/PlaylistLoader.cs
@@ -14,6 +14,9 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
     [SerializeField] private string _poolId = "default";
     [SerializeField] private string _poolBaseUrl = "https://playlist.vrc-hub.com";
     [SerializeField] private int _poolSize = 100000;
+    [SerializeField] private bool _autoLoadOnStart;
+    [SerializeField] private VRCUrl _autoLoadUrl;
+    [SerializeField, Range(0, 60)] private float _autoLoadDelay;
 
     private bool _isLoading;
     private VRCUrl _pendingResolveUrl;
@@ -21,6 +24,23 @@ namespace Yamadev.YamaStream.Modules.PlaylistLoader
     public VRCUrl[] RedirectPool => _redirectPool;
     public string PoolId => _poolId;
     public bool IsLoading => _isLoading;
+
+    public override void Start()
+    {
+      base.Start();
+      if (!Utilities.IsValid(_controller)) return;
+      if (!Networking.IsMaster && !_controller.IsLocal) return;
+      if (!_autoLoadOnStart) return;
+      if (string.IsNullOrEmpty(_autoLoadUrl.Get())) return;
+      if (_redirectPool.Length == 0) return;
+      SendCustomEventDelayedSeconds(nameof(LoadDefaultPlaylist), _autoLoadDelay);
+    }
+
+    public void LoadDefaultPlaylist()
+    {
+      if (_isLoading || _controller.IsLoading) return;
+      LoadPlaylistFromUrl(_autoLoadUrl);
+    }
 
     public void LoadPlaylistFromUrl(VRCUrl resolveUrl)
     {


### PR DESCRIPTION
## Summary

- PlaylistLoader にワールド参加時の自動プレイリスト読み込み機能を追加
- `_autoLoadOnStart`, `_autoLoadUrl`, `_autoLoadDelay` の3フィールドを追加し、Start() で条件を満たした場合に `LoadPlaylistFromUrl()` を遅延実行
- エディタ UI に Auto Load セクションを追加（トグル OFF 時は URL/Delay 非表示）

### 設計判断

AutoPlay モジュールではなく PlaylistLoader 側に実装。理由:
- PlaylistLoader が VhubPlaylist インフラ（VRCStringDownloader, JSONパース, redirectPool, Queue追加）を全て保有
- モジュール間依存を増やさない
- 責務分離: AutoPlay=静的再生開始, PlaylistLoader=動的プレイリスト読み込み

### ガード条件

**Start()**: `_controller` 有効 / Master or Local / `_autoLoadOnStart` / URL非空 / Pool非空
**LoadDefaultPlaylist()**: `!_isLoading` / `!_controller.IsLoading`（二重実行防止）

## Test plan

- [ ] Unity でコンパイルエラーがないこと
- [ ] PlaylistLoader インスペクタに Auto Load セクションが表示されること
- [ ] Auto Load On Start OFF 時に URL/Delay フィールドが非表示になること
- [ ] Auto Load On Start ON + Resolve URL 設定でワールド参加時にプレイリストが自動読み込みされること
- [ ] 既に再生中の場合は Queue に追加のみで再生を中断しないこと

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)