### PR TITLE
feat: enable VPM repository support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,9 @@ jobs:
             ${{ env.unityPackage }}
             Packages/${{ env.packageName }}/package.json
 
-      # TODO: KawaPlayer 用 VPM リポジトリ作成後に有効化する
-      # - name: Build Listing
-      #   uses: peter-evans/repository-dispatch@v3
-      #   with:
-      #     token: ${{ secrets.PAT }}
-      #     repository: Mega-Gorilla/vpm-repos
-      #     event-type: build-listing
+      - name: Build Listing
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: Mega-Gorilla/vpm-repos
+          event-type: build-listing

--- a/Editor/Package/PackageManager.cs
+++ b/Editor/Package/PackageManager.cs
@@ -9,9 +9,8 @@ namespace Yamadev.YamaStream.Editor
   [InitializeOnLoad]
   public static class PackageManager
   {
-    // TODO: KawaPlayer 用の VPM リポジトリを構築したら repo ID と URL を更新する
-    public const string VpmId = "net.kwxxw.vpm";
-    public const string VpmUrl = "https://vpm.kwxxw.net/index.json";
+    public const string VpmId = "com.vhub.vpm";
+    public const string VpmUrl = "https://mega-gorilla.github.io/vpm-repos/index.json";
     private const string CheckBetaKey = "YamaPlayer_CheckBetaUpdate";
 
     public static bool HasNewVersion { get; private set; } = false;

--- a/README.md
+++ b/README.md
@@ -34,7 +34,20 @@ YamaPlayer は VRChat で使うことを想定して作られた動画プレイ�
 
 ## 導入手順
 
-### 新規導入（YamaPlayer 未導入の場合）
+### VCC（VRChat Creator Companion）で導入（推奨）
+
+1. VCC で以下の URL をリポジトリとして追加:
+   ```
+   https://mega-gorilla.github.io/vpm-repos/index.json
+   ```
+   VCC メニュー: **Settings > Packages > Add Repository** に URL を入力
+2. VCC の **Manage Project** でプロジェクトを開く
+3. **KawaPlayer** の **Add** をクリック
+4. Unity を開き、**GameObject > KawaPlayer > Main** メニューまたは `KawaPlayer.prefab` をシーンにドラッグして配置
+
+> VCC で導入した場合、アップデートも VCC 上からワンクリックで実行できます。
+
+### .unitypackage で導入
 
 1. VRChat Worlds SDK (>=3.8.1) が導入済みの Unity プロジェクトを用意
 2. [Releases ページ](https://github.com/Mega-Gorilla/KawaPlayer/releases) から `com.vhub.kawaplayer-x.x.x.unitypackage` をダウンロード
@@ -51,7 +64,7 @@ KawaPlayer は YamaPlayer と同じアセンブリ定義を使用しているた
    - **.unitypackage で導入した場合:** Unity メニュー **Window > Package Manager** で YamaPlayer を選択し **Remove** をクリック
 3. `Packages/net.kwxxw.yama-stream/` フォルダが残っていないことを確認
 4. **Unity を開き**、コンパイルエラーがないことを確認
-5. [Releases ページ](https://github.com/Mega-Gorilla/KawaPlayer/releases) から `.unitypackage` をダウンロードしインポート
+5. 上記の「VCC で導入」または「.unitypackage で導入」の手順で KawaPlayer を導入
 6. シーン内の YamaPlayer プレハブを `KawaPlayer.prefab` に置き換え
 
 ### PlaylistLoader の設定


### PR DESCRIPTION
## Summary
- VCC (VRChat Creator Companion) / VPM 経由でのインストール・更新に対応
- `Mega-Gorilla/vpm-repos` リポジトリを新規作成し、GitHub Pages で VPM listing を公開
- KawaPlayer リリース時に自動で listing を再ビルドする仕組みを構築

## 変更内容

### KawaPlayer (本PR)
- `Editor/Package/PackageManager.cs`: `VpmId` / `VpmUrl` を KawaPlayer 用 VPM リポジトリに更新
  - `net.kwxxw.vpm` → `com.vhub.vpm`
  - `https://vpm.kwxxw.net/index.json` → `https://mega-gorilla.github.io/vpm-repos/index.json`
- `.github/workflows/release.yml`: repository-dispatch ステップを有効化（リリース時に vpm-repos の listing 再ビルドをトリガー）

### vpm-repos (別リポジトリ、作成済み)
- `vrchat-community/template-package-listing` テンプレートから作成
- `source.json`: KawaPlayer を `githubRepos` に登録
- `build-listing.yml`: `repository_dispatch` トリガーを追加

## インフラ確認状況
- ✅ `secrets.PAT` 設定済み
- ✅ `index.json` 公開確認済み（`com.vhub.kawaplayer` 全3バージョン収録）
- ⏳ VCC での実機確認（Add Repository → KawaPlayer 表示・インストール）

Refs #34

## Test plan
- [x] `https://mega-gorilla.github.io/vpm-repos/index.json` に `com.vhub.kawaplayer` がリストされる
- [ ] Unity Editor でコンパイルエラーなし
- [ ] VCC「Add Repository」で KawaPlayer が表示・インストール可能
- [ ] 次回リリース時に repository-dispatch が成功し listing が再ビルドされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)