### PR TITLE
feat(modules): add PersistedAutoPlay module — per-player URL persistence

### DIFF
--- a/Modules/PersistedAutoPlay.meta
+++ b/Modules/PersistedAutoPlay.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8181db936811d44ca90d70c866bad35
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/PersistedAutoPlay/PersistedAutoPlay.asset
+++ b/Modules/PersistedAutoPlay/PersistedAutoPlay.asset
@@ -1,0 +1,179 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: PersistedAutoPlay
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: a606c9077f6246b4a9ad6b72d85bb73d,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: 1a39c1cd71fbf8c4eaa03b115fffd686, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 4
+  hasInteractEvent: 0
+  scriptID: 5638650481780612134
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _loader
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _loader
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Yamadev.YamaStream.Modules.PlaylistLoader.PlaylistLoader, Yamadev.YamaStream.Modules.PlaylistLoader
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 4|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.Udon.UdonBehaviour, VRC.Udon
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 5|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 6|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _persistedUrl
+    - Name: $v
+      Entry: 7
+      Data: 7|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _persistedUrl
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 8|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.SDKBase.VRCUrl, VRCSDKBase
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 8
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 9|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 10|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Modules/PersistedAutoPlay/PersistedAutoPlay.asset.meta
+++ b/Modules/PersistedAutoPlay/PersistedAutoPlay.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c716f5f9a1aa472418f55e6533eb0e80
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/PersistedAutoPlay/PersistedAutoPlay.cs
+++ b/Modules/PersistedAutoPlay/PersistedAutoPlay.cs
@@ -1,0 +1,55 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Components;
+using VRC.SDK3.StringLoading;
+using VRC.SDKBase;
+using VRC.Udon.Common;
+using VRC.Udon.Common.Interfaces;
+
+namespace Yamadev.YamaStream.Modules.PersistedAutoPlay
+{
+    [RequireComponent(typeof(VRCPlayerObject))]
+    [RequireComponent(typeof(VRCEnablePersistence))]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+    public class PersistedAutoPlay : YamaPlayerListener
+    {
+        [SerializeField] private Yamadev.YamaStream.Modules.PlaylistLoader.PlaylistLoader _loader;
+
+        [UdonSynced] private VRCUrl _persistedUrl = VRCUrl.Empty;
+
+        public bool HasPersistedUrl => Utilities.IsValid(_persistedUrl) && !string.IsNullOrEmpty(_persistedUrl.Get());
+        public VRCUrl PersistedUrl => _persistedUrl;
+
+        public void SaveCurrentUrl(VRCUrl url)
+        {
+            if (!Networking.IsOwner(gameObject)) return;
+            _persistedUrl = url;
+            RequestSerialization();
+        }
+
+        public void ClearSavedUrl()
+        {
+            if (!Networking.IsOwner(gameObject)) return;
+            _persistedUrl = VRCUrl.Empty;
+            RequestSerialization();
+        }
+
+        public override void OnPlayerRestored(VRCPlayerApi player)
+        {
+            if (player != Networking.LocalPlayer) return;
+            if (!Utilities.IsValid(_persistedUrl)) return;
+            if (string.IsNullOrEmpty(_persistedUrl.Get())) return;
+            if (!Utilities.IsValid(_loader) || _loader.IsLoading) return;
+            if (_loader.RedirectPool == null || _loader.RedirectPool.Length == 0) return;
+            _loader.LoadPlaylistFromUrl(_persistedUrl);
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (_loader == null)
+                Debug.LogWarning("[PersistedAutoPlay] " + gameObject.name + ": _loader (PlaylistLoader) is not set.", this);
+        }
+#endif
+    }
+}

--- a/Modules/PersistedAutoPlay/PersistedAutoPlay.cs.meta
+++ b/Modules/PersistedAutoPlay/PersistedAutoPlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a39c1cd71fbf8c4eaa03b115fffd686
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/PersistedAutoPlay/PersistedAutoPlay.prefab
+++ b/Modules/PersistedAutoPlay/PersistedAutoPlay.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3169948652119336618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7192650942477421234}
+  - component: {fileID: 5177900040346082944}
+  - component: {fileID: 4871109225197539731}
+  - component: {fileID: 3279369661189855610}
+  - component: {fileID: 8087681354754964298}
+  m_Layer: 0
+  m_Name: PersistedAutoPlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7192650942477421234
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3169948652119336618}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5177900040346082944
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3169948652119336618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1658641376, guid: 661092b4961be7145bfbe56e1e62337b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4871109225197539731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3169948652119336618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1864912870, guid: 661092b4961be7145bfbe56e1e62337b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3279369661189855610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3169948652119336618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a39c1cd71fbf8c4eaa03b115fffd686, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []
+  _udonSharpBackingUdonBehaviour: {fileID: 8087681354754964298}
+  _loader: {fileID: 0}
+--- !u!114 &8087681354754964298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3169948652119336618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45115577ef41a5b4ca741ed302693907, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTextPlacement: {fileID: 0}
+  interactText: Use
+  interactTextGO: {fileID: 0}
+  proximity: 2
+  SynchronizePosition: 0
+  AllowCollisionOwnershipTransfer: 0
+  Reliable: 0
+  _syncMethod: 0
+  serializedProgramAsset: {fileID: 11400000, guid: a606c9077f6246b4a9ad6b72d85bb73d,
+    type: 2}
+  programSource: {fileID: 11400000, guid: c716f5f9a1aa472418f55e6533eb0e80, type: 2}
+  serializedPublicVariablesBytesString: Ai8AAAAAATIAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAFQAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AAAAAAAYBAAAAAAAAACcBBAAAAHQAeQBwAGUAAWgAAABTAHkAcwB0AGUAbQAuAEMAbwBsAGwAZQBjAHQAaQBvAG4AcwAuAEcAZQBuAGUAcgBpAGMALgBMAGkAcwB0AGAAMQBbAFsAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4ALgBJAG4AdABlAHIAZgBhAGMAZQBzAC4ASQBVAGQAbwBuAFYAYQByAGkAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AXQBdACwAIABtAHMAYwBvAHIAbABpAGIAAQEJAAAAVgBhAHIAaQBhAGIAbABlAHMALwEAAAABaAAAAFMAeQBzAHQAZQBtAC4AQwBvAGwAbABlAGMAdABpAG8AbgBzAC4ARwBlAG4AZQByAGkAYwAuAEwAaQBzAHQAYAAxAFsAWwBWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAEkAbgB0AGUAcgBmAGEAYwBlAHMALgBJAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlACwAIABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgBdAF0ALAAgAG0AcwBjAG8AcgBsAGkAYgABAAAABgEAAAAAAAAAAi8CAAAAAUkAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAGAAMQBbAFsAUwB5AHMAdABlAG0ALgBJAG4AdAAzADIALAAgAG0AcwBjAG8AcgBsAGkAYgBdAF0ALAAgAFYAUgBDAC4AVQBkAG8AbgAuAEMAbwBtAG0AbwBuAAIAAAAGAgAAAAAAAAAnAQQAAAB0AHkAcABlAAEXAAAAUwB5AHMAdABlAG0ALgBTAHQAcgBpAG4AZwAsACAAbQBzAGMAbwByAGwAaQBiACcBCgAAAFMAeQBtAGIAbwBsAE4AYQBtAGUAAR8AAABfAF8AXwBVAGQAbwBuAFMAaABhAHIAcABCAGUAaABhAHYAaQBvAHUAcgBWAGUAcgBzAGkAbwBuAF8AXwBfACcBBAAAAHQAeQBwAGUAARYAAABTAHkAcwB0AGUAbQAuAEkAbgB0ADMAMgAsACAAbQBzAGMAbwByAGwAaQBiABcBBQAAAFYAYQBsAHUAZQACAAAABwUHBQcF
+  publicVariablesUnityEngineObjects: []
+  publicVariablesSerializationDataFormat: 0

--- a/Modules/PersistedAutoPlay/PersistedAutoPlay.prefab.meta
+++ b/Modules/PersistedAutoPlay/PersistedAutoPlay.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 58e9f6eca5c84de42b4467b87189148c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asmdef
+++ b/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Yamadev.YamaStream.Modules.PersistedAutoPlay",
+    "rootNamespace": "",
+    "references": [
+        "GUID:99835874ee819da44948776e0df4ff1d",
+        "GUID:befb3e42bf02a9b488522ef543d61aa0",
+        "GUID:62cd893d70c246c08cab22f63d0f47a2"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asmdef.meta
+++ b/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4daaaf7cc932994a965587c2c50c3ed
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asset
+++ b/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5136146375e9a0a498a72a0091b40cc1, type: 3}
+  m_Name: Yamadev.YamaStream.Modules.PersistedAutoPlay
+  m_EditorClassIdentifier: 
+  sourceAssembly: {fileID: 5897886265953266890, guid: c4daaaf7cc932994a965587c2c50c3ed,
+    type: 3}

--- a/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asset.meta
+++ b/Modules/PersistedAutoPlay/Yamadev.YamaStream.Modules.PersistedAutoPlay.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bdbcf26f7157ba428715ed9f8bb2798
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- 新規モジュール `Modules/PersistedAutoPlay/` を追加 (Epic #44, Issue #46)
- VRChat Persistence (`VRCPlayerObject + VRCEnablePersistence + [UdonSynced] VRCUrl`) を使い、ユーザー入力の VHub Playlist URL を **プレイヤーごとに永続化** し再Join時に自動再生する基盤
- PoC #45 で実機検証済みの中核仮説をそのまま実装に落とし込み

## Implementation

| ファイル | 内容 |
|---|---|
| `PersistedAutoPlay.cs` | `YamaPlayerListener` 継承の UdonSharpBehaviour。`SaveCurrentUrl(VRCUrl)` / `ClearSavedUrl()` / `OnPlayerRestored` を実装 |
| `PersistedAutoPlay.asset` | UdonSharpProgramAsset (compiled) |
| `PersistedAutoPlay.prefab` | PlayerObject template (`VRCPlayerObject + VRCEnablePersistence + 本UdonSharpBehaviour` 同 GameObject、standalone) |
| `Yamadev.YamaStream.Modules.PersistedAutoPlay.asmdef` | アセンブリ定義 (UdonSharp.Runtime + YamaStream.Runtime + PlaylistLoader 参照) |
| `Yamadev.YamaStream.Modules.PersistedAutoPlay.asset` | UdonSharpAssemblyDefinition (U# にこのアセンブリを登録) |

### Design 決定 (Issue #46 v1.1 を反映)

- **`YamaPlayerListener` 継承** (NOT YamaPlayerModule): PlayerObject lifecycle と Module lifecycle の混在を避ける
- **PlayerObject template として独立 prefab**: 既存モジュール (AutoPlay, Persistence) と同じパターン。KawaPlayer.prefab には統合せず、ユーザーが必要に応じて追加配置
- **OnPlayerRestored ガード**: \`!IsLoading\` / \`RedirectPool.Length > 0\` / \`!Networking.LocalPlayer\` 等の防御チェック追加 (#46 v1.1 ⑤)
- **Editor 拡張は v1 では不要**: \`OnValidate()\` で軽量バリデーションのみ実装 (#46 v1.1 ④)
- **VRCUrl.Empty 初期化必須**: ClientSim クラッシュ回避 (PoC #45 で判明)

## What's NOT in this PR

以下は別 PR / issue で対応:

- **#47 PlaylistLoaderUI への 「お気に入り保存」UI 統合** — KawaPlayer.prefab / ScreenUI.prefab 修正を含むため独立 PR で実施予定
- **#48 ローカライゼーション (8言語)**
- **#49 実機検証** (Solo Local mode / Multi-player / 既存 AutoPlay 併存)
- **#50 ドキュメント更新** (README / CLAUDE.md / updatelog.txt)

## Test plan

- [x] `Modules/PersistedAutoPlay/` 配下 5 ファイル + .meta が新規追加 (11 files total)
- [x] testing-chamber Unity でコンパイルエラー 0 件
- [x] `IsUdonSharpAssembly(\"Yamadev.YamaStream.Modules.PersistedAutoPlay\") == True`
- [x] PersistedAutoPlay.prefab を Unity Editor で開いて 5 component 表示 (Transform + VRCPlayerObject + VRCEnablePersistence + PersistedAutoPlay + UdonBehaviour)
- [x] backing UdonBehaviour が PersistedAutoPlay.asset を programSource として参照
- [ ] VRChat 実機での動作検証は #49 (フィーチャー統合後)

## Refs

- Epic: #44
- PoC: #45 (closed, GO)
- Closes: #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)