### PR TITLE
docs(readme): restructure to focus on differentiation from YamaPlayer (closes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KawaPlayer
 
-VRChat の動画プレイヤー [YamaPlayer](https://github.com/koorimizuw/YamaPlayer) のフォーク。**ワールド作成者が VRChat 内から直接プレイリストやデフォルト URL を設定できる**機能を追加しています。
+VRChat の動画プレイヤー [YamaPlayer](https://github.com/koorimizuw/YamaPlayer) のフォーク。**ワールド作成者が VRChat 内から直接プレイリストやデフォルト動画URL を設定できる**機能を追加しています。
 
 > **YamaPlayer を置き換えて使用するパッケージです。** 同時インストール不可。既存 YamaPlayer ユーザは [移行手順](#yamaplayer-からの移行) を参照してください。
 
@@ -15,8 +15,8 @@ VRChat の動画プレイヤー [YamaPlayer](https://github.com/koorimizuw/YamaP
 | AudioLink / LTCGI / Light Volume 連携 | ✓ | ✓ (継承) |
 | 多言語対応 (9 言語) | ✓ | ✓ (継承) |
 | **外部プレイリスト URL の読込** (`playlist.vrc-hub.com`) | — | ✅ NEW |
-| **ワールドのデフォルト URL を VRChat 内から設定** | — | ✅ NEW |
-| **デフォルト URL の永続化** (再 join で自動復元) | — | ✅ NEW |
+| **ワールドのデフォルト動画URL を VRChat 内から設定** | — | ✅ NEW |
+| **デフォルト動画URL の永続化** (再 join で自動復元) | — | ✅ NEW |
 
 KawaPlayer は YamaPlayer の全機能を継承しつつ、**ワールド作成者が VRChat 内で動画/プレイリストを直接管理できる**機能を追加しています。
 
@@ -50,7 +50,7 @@ KawaPlayer は YamaPlayer の全機能を継承しつつ、**ワールド作成�
 
 外部プレイリストを世界の事前ビルドに焼き込む必要なく、**VRChat に居ながら好みのプレイリストを切替できます**。
 
-### デフォルト URL 機能 (DefaultUrl)
+### デフォルト動画URL 機能 (DefaultUrl)
 
 ワールドの **「入室時に自動再生される動画 / プレイリスト URL」** を、Instance Owner が VRChat 内から設定できる機能です。
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ KawaPlayer は YamaPlayer の全機能を継承しつつ、**ワールド作成�
 
 ## クイックスタート (VCC 推奨)
 
-1. VCC の **Settings > Packages > Add Repository** に以下を追加:
-   ```
-   https://mega-gorilla.github.io/vpm-repos/index.json
-   ```
+1. VCC にリポジトリを追加 — 以下のいずれかの方法で:
+   - **ワンクリック追加**: [このリンクをクリック](vcc://vpm/addRepo?url=https://mega-gorilla.github.io/vpm-repos/index.json) して VCC で開く
+   - **手動追加**: VCC の **Settings > Packages > Add Repository** に下記 URL を入力
+
+     ```
+     https://mega-gorilla.github.io/vpm-repos/index.json
+     ```
 2. **Manage Project** で対象プロジェクトを開き、**KawaPlayer** の **Add** をクリック
 3. Unity で `KawaPlayer.prefab` をシーンにドラッグ (または **GameObject > KawaPlayer > Main** メニュー)
 

--- a/README.md
+++ b/README.md
@@ -1,113 +1,116 @@
 # KawaPlayer
 
-[YamaPlayer](https://github.com/koorimizuw/YamaPlayer) のフォークリポジトリです。YamaPlayer の全機能に加え、外部プレイリストのランタイム読み込み機能 (PlaylistLoader) と Owner-tied default URL 機能 (DefaultUrl) を搭載しています（基本機能実装済み・VRChat 実機検証継続中）。
+VRChat の動画プレイヤー [YamaPlayer](https://github.com/koorimizuw/YamaPlayer) のフォーク。**ワールド作成者が VRChat 内で直接プレイリストやデフォルト URL を設定できる**ようにすることで、World creator 体験 (WCX) を強化しています。
 
-> **KawaPlayer は YamaPlayer を置き換えて使用するパッケージです。** YamaPlayer と同時にインストールすることはできません。YamaPlayer を導入済みの場合は、下記の「YamaPlayer からの移行」手順に従ってください。
+> **YamaPlayer を置き換えて使用するパッケージです。** 同時インストール不可。既存 YamaPlayer ユーザは [移行手順](#yamaplayer-からの移行) を参照してください。
 
-## PlaylistLoader
+---
 
-[playlist.vrc-hub.com](https://playlist.vrc-hub.com) で作成したプレイリストを、VRChat ワールド内の動画プレイヤーに読み込む機能です。
+## YamaPlayer との違い
 
-### 仕組み
+| 機能 | YamaPlayer | KawaPlayer |
+|---|---|---|
+| 動画再生 (YouTube / Twitch / HLS / 直リンク) | ✓ | ✓ (継承) |
+| カラオケ / 区間リピート / 再生速度 / 最大解像度 | ✓ | ✓ (継承) |
+| AudioLink / LTCGI / Light Volume 連携 | ✓ | ✓ (継承) |
+| 多言語対応 (9 言語) | ✓ | ✓ (継承) |
+| **外部プレイリスト URL の読込** (`playlist.vrc-hub.com`) | — | ✅ NEW |
+| **ワールドのデフォルト URL を VRChat 内から設定** | — | ✅ NEW |
+| **デフォルト URL の永続化** (再 join で自動復元) | — | ✅ NEW |
 
-1. ワールド制作者がビルド時に VRCUrl Pool を生成（Editor の Generate Pool ボタン）
-2. VRChat 内でユーザーがプレイリスト URL を入力
-3. サーバーからプレイリスト情報を取得し、Queue にトラックを一括追加
-4. 停止中なら自動再生開始
+KawaPlayer は YamaPlayer の全機能を継承しつつ、**ワールド作成者が VRChat 内で動画/プレイリストを直接管理できる**機能を追加しています。
 
-VRChat/Udon の制約（ランタイムで `string → VRCUrl` 変換が不可能）を回避するため、**Pre-baked URL Pool + リダイレクトサーバー方式**を採用しています。
+---
 
-## DefaultUrl
+## クイックスタート (VCC 推奨)
 
-ワールドの **「デフォルト動画 / プレイリスト URL」** を VRChat 内で Instance Owner が設定し、自動再生 + セッション間永続化する機能です。
-
-### 使い方 (Owner として)
-
-1. ワールドに入る (Instance Owner として)
-2. KawaPlayer UI を開く → **Settings** → **Playback** タブ
-3. 末尾の **Default URL** セクションで URL を入力 → **保存** をクリック
-4. プレイヤーが停止中であれば即時に再生が開始されます (再生中・一時停止中の場合は中断せず、URL は次回以降の autoplay 対象として保存されます)
-5. 保存した URL は **次回以降の入室時にも自動的に復元** されます (VRChat Persistence による永続化)
-
-### 仕組み
-
-- **Layer 1 (instance sync)**: 設定された URL は `[UdonSynced]` で同 instance の全 player に同期、Master が autoplay を起動
-- **Layer 2 (Owner persistence)**: Owner の `VRCPlayerObject + VRCEnablePersistence` で URL を永続化、再 join 時に自動復元
-- **URL 種別自動判定**: `playlist.vrc-hub.com` を含めば PlaylistLoader 経路、それ以外は直接動画再生
-- **Owner 限定 UI**: Save / Clear ボタンは Instance Owner にのみ表示 (他 player は現在の URL 表示のみ)
-
-### KawaPlayer.prefab に内蔵 (zero-setup)
-
-`v1.1.0` 以降、DefaultUrl は **KawaPlayer.prefab に内蔵されています**。`KawaPlayer.prefab` を scene に配置するだけで利用可能で、別途 prefab を追加する必要はありません。`v1.1.1` 以降は直接 embed され、別 `DefaultUrl.prefab` ファイルは存在しません。`v1.1.2` 以降は UI セクションが他 settings (再生速度・区間リピート 等) と同じ `ScreenUI/.../PlaybackView/Content` 配下に直接配置され、Hierarchy 上で WYSIWYG に編集可能です。
-
-## YamaPlayer について
-
-YamaPlayer は VRChat で使うことを想定して作られた動画プレイヤーです。以下の機能を備えています。
-
-- YouTube、Twitch 等の動画・ストリーミング再生
-- 動画タイトルの自動ロード
-- 再生速度変更、区間リピート、最大解像度変更
-- カラオケモード
-- 再生キュー、再生履歴、プレイリスト
-- ネットワーク同期（ユーザ間の遅延を内部で計算）
-- AudioLink / LTCGI サポート
-- 多言語対応
-
-詳細は [本家 YamaPlayer](https://github.com/koorimizuw/YamaPlayer) を参照してください。
-
-## 導入手順
-
-### VCC（VRChat Creator Companion）で導入（推奨）
-
-1. VCC で以下の URL をリポジトリとして追加:
+1. VCC の **Settings > Packages > Add Repository** に以下を追加:
    ```
    https://mega-gorilla.github.io/vpm-repos/index.json
    ```
-   VCC メニュー: **Settings > Packages > Add Repository** に URL を入力
-2. VCC の **Manage Project** でプロジェクトを開く
-3. **KawaPlayer** の **Add** をクリック
-4. Unity を開き、**GameObject > KawaPlayer > Main** メニューまたは `KawaPlayer.prefab` をシーンにドラッグして配置
+2. **Manage Project** で対象プロジェクトを開き、**KawaPlayer** の **Add** をクリック
+3. Unity で `KawaPlayer.prefab` をシーンにドラッグ (または **GameObject > KawaPlayer > Main** メニュー)
 
-> VCC で導入した場合、アップデートも VCC 上からワンクリックで実行できます。
+これで KawaPlayer の全機能 (PlaylistLoader / DefaultUrl 含む) が **追加設定なしで** 使えます。
 
-### .unitypackage で導入
+> アップデートも VCC からワンクリックで実行できます。
 
-1. VRChat Worlds SDK (>=3.8.1) が導入済みの Unity プロジェクトを用意
-2. [Releases ページ](https://github.com/Mega-Gorilla/KawaPlayer/releases) から `com.vhub.kawaplayer-x.x.x.unitypackage` をダウンロード
-3. Unity メニュー: **Assets > Import Package > Custom Package** で `.unitypackage` をインポート
-4. **GameObject > KawaPlayer > Main** メニュー、または `KawaPlayer.prefab` をシーンにドラッグして配置
+---
 
-### YamaPlayer からの移行
+## 主要機能 (KawaPlayer 独自)
 
-KawaPlayer は YamaPlayer と同じアセンブリ定義を使用しているため、**YamaPlayer を先に削除してから** KawaPlayer を導入してください。両方が同時に存在するとコンパイルエラーが発生します。
+### 外部プレイリスト読込 (PlaylistLoader)
+
+[playlist.vrc-hub.com](https://playlist.vrc-hub.com) で作成したプレイリストを、VRChat 内から動画プレイヤーに読み込む機能です。
+
+**使い方:**
+1. ワールド内の KawaPlayer UI でプレイリスト URL を入力
+2. プレイリストの全トラックが Queue に追加される
+3. 停止中なら自動再生開始
+
+外部プレイリストを世界の事前ビルドに焼き込む必要なく、**VRChat に居ながら好みのプレイリストを切替できます**。
+
+### デフォルト URL 機能 (DefaultUrl)
+
+ワールドの **「入室時に自動再生される動画 / プレイリスト URL」** を、Instance Owner が VRChat 内から設定できる機能です。
+
+**使い方 (Owner として):**
+1. ワールドに Instance Owner として入室
+2. KawaPlayer UI を開く → **Settings → Playback** タブ
+3. 末尾の **Default URL** セクションで URL を入力 → **保存** をクリック
+4. プレイヤーが停止中であれば即時再生開始 (再生中の場合は中断せず、次回ロード時に反映)
+5. 保存した URL は **次回入室時にも自動復元** されます
+
+**機能特性:**
+- **動画 URL / プレイリスト URL の自動判定** — `playlist.vrc-hub.com` を含めばプレイリスト経路、それ以外は動画再生経路
+- **Owner 限定編集** — 他 player には現在の URL のみ表示 (read-only)
+- **マルチプレイヤー同期** — Owner の設定は instance 内全 player に同期、後続 joiner も自動再生される
+- **永続化** — Owner の VRChat アカウントに紐づき、次回入室時に自動復元
+
+---
+
+## YamaPlayer からの移行
+
+KawaPlayer は YamaPlayer と同じアセンブリ定義を使用しているため、**両方を同時にインストールすると C# コンパイルエラーが発生**します。下記手順で置き換えてください。
 
 1. **Unity を閉じる**
 2. **YamaPlayer を削除**
-   - **VCC で導入した場合:** VCC の **Manage Project** でプロジェクトを開き、YamaPlayer の **Remove Package** をクリック
-   - **.unitypackage で導入した場合:** Unity メニュー **Window > Package Manager** で YamaPlayer を選択し **Remove** をクリック
+   - **VCC で導入の場合:** VCC の **Manage Project** から YamaPlayer の **Remove Package**
+   - **.unitypackage で導入の場合:** Unity **Window > Package Manager** で YamaPlayer を選択 → **Remove**
 3. `Packages/net.kwxxw.yama-stream/` フォルダが残っていないことを確認
-4. **Unity を開き**、コンパイルエラーがないことを確認
-5. 上記の「VCC で導入」または「.unitypackage で導入」の手順で KawaPlayer を導入
+4. **Unity を開き直し**、コンパイルエラーがないことを確認
+5. 上記の [クイックスタート](#クイックスタート-vcc-推奨) で KawaPlayer を導入
 6. シーン内の YamaPlayer プレハブを `KawaPlayer.prefab` に置き換え
 
-### PlaylistLoader の設定
+---
 
-PlaylistLoader は KawaPlayer.prefab に組み込み済みです。デフォルトの Pool ID (`default`) がそのまま利用可能です。Pool ID を変更する場合のみ、PlaylistLoader の Inspector で Pool ID を設定し Generate Pool を実行してください。
+## YamaPlayer 機能 (継承)
 
-### DefaultUrl の設定
+YamaPlayer の動画プレイヤーとしての全機能 — YouTube/Twitch/HLS 再生、カラオケモード、再生キュー / 履歴 / プレイリスト、ネットワーク同期、AudioLink / LTCGI 連携、多言語対応 (9 言語)、再生速度 / 区間リピート / 最大解像度設定 等 — をすべて継承しています。
 
-DefaultUrl は KawaPlayer.prefab に組み込み済みです (v1.1.0 以降)。設定不要で、配置後そのまま VRChat 内 Settings UI から利用できます。Owner として URL を設定すると、次回以降も自動復元されます。
+詳細は [本家 YamaPlayer](https://github.com/koorimizuw/YamaPlayer) を参照してください。
+
+---
+
+## .unitypackage で導入 (VCC を使わない場合)
+
+1. VRChat Worlds SDK (>=3.8.1) 導入済みの Unity プロジェクトを用意
+2. [Releases ページ](https://github.com/Mega-Gorilla/KawaPlayer/releases) から `com.vhub.kawaplayer-x.x.x.unitypackage` をダウンロード
+3. Unity メニュー **Assets > Import Package > Custom Package** でインポート
+4. **GameObject > KawaPlayer > Main** または `KawaPlayer.prefab` をシーンにドラッグ
+
+---
 
 ## 利用規約
 
 本家 YamaPlayer の利用規約に準じます。
 
-許可：
-改変
-ワールドの一部としてVRChatでの公開
-有償・無償問わず販売ワールドアセットへの取り組み
+許可:
+- 改変
+- ワールドの一部として VRChat での公開
+- 有償・無償問わず販売ワールドアセットへの取り組み
 
-クレジット記載は任意です、ただし販売ワールドアセットへ取り組む場合クレジット記載は必須です。
+クレジット記載は任意ですが、**販売ワールドアセットに取り組む場合はクレジット記載が必須**です。
 
 ## クレジット
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KawaPlayer
 
-VRChat の動画プレイヤー [YamaPlayer](https://github.com/koorimizuw/YamaPlayer) のフォーク。**ワールド作成者が VRChat 内で直接プレイリストやデフォルト URL を設定できる**ようにすることで、World creator 体験 (WCX) を強化しています。
+VRChat の動画プレイヤー [YamaPlayer](https://github.com/koorimizuw/YamaPlayer) のフォーク。**ワールド作成者が VRChat 内から直接プレイリストやデフォルト URL を設定できる**機能を追加しています。
 
 > **YamaPlayer を置き換えて使用するパッケージです。** 同時インストール不可。既存 YamaPlayer ユーザは [移行手順](#yamaplayer-からの移行) を参照してください。
 


### PR DESCRIPTION
## Summary

`README.md` を **「YamaPlayer との差分にフォーカス」** した構成に再構成 (Issue #64)。reader が KawaPlayer を選ぶ理由を画面 1 枚目で判断できる状態にし、技術内部詳細を user-facing 部分から除去。

- **比較表** を画面 1 枚目に配置 → YamaPlayer 機能 (継承) と KawaPlayer 独自機能を一目で判別
- **YamaPlayer 機能の冗長な再掲** (14 行) を 1 段落に圧縮 + upstream link
- **実装詳細** (`[UdonSynced]`, `VRCPlayerObject + VRCEnablePersistence`, `Pre-baked URL Pool` 等) を README から除去 — feature-level 説明のみ残す
- **クイックスタート (VCC)** を上位に配置、`.unitypackage` 手順は副次的位置に降格
- **既存セクション維持**: Migration / License / Credits は内容変更なし

## 動機

v1.1.2 で 9 言語対応により reach 拡大。VCC で初めて KawaPlayer を見つけた world creator が **「YamaPlayer から乗り換える理由」「新規で選ぶ理由」を即座に判断** できる README が必要。現状は:

1. YamaPlayer の機能カタログを再掲 → upstream リンクで足りるのに重複
2. 比較表が無い → 散文から差分を読み解く必要あり
3. 実装詳細が "使い方" セクションに混在 → user 動機 (= 使い方) と乖離
4. Value proposition が暗黙的 → 直接的な訴求が無い

## 主要変更

### Before (v1.1.2 時点) の構成

```
1. # KawaPlayer + 1 行説明
2. PlaylistLoader 機能 (使い方 + 仕組み)
3. DefaultUrl 機能 (使い方 + 仕組み)
4. YamaPlayer について (機能 14 行列挙、要は upstream link)
5. 導入手順 (VCC + unitypackage 並列)
6. YamaPlayer からの移行
7. PlaylistLoader / DefaultUrl の設定 (副次的補足)
8. 利用規約 / クレジット
```

### After (本 PR) の構成

```
1. # KawaPlayer + 1-2 行 value proposition
2. ## YamaPlayer との違い  ⬅ NEW、画面 1 枚目に比較表
3. ## クイックスタート (VCC、3 ステップ)  ⬅ 上位昇格
4. ## 主要機能 (KawaPlayer 独自) — 使い方フォーカス
   ### 外部プレイリスト読込 (PlaylistLoader)
   ### デフォルト URL 機能 (DefaultUrl)
5. ## YamaPlayer からの移行 — 既存 user 向け
6. ## YamaPlayer 機能 (継承)  ⬅ 14 行 → 1 段落 + upstream link
7. ## .unitypackage で導入  ⬅ 副次的位置に降格
8. ## 利用規約 / クレジット
```

## 比較表 (新規導入)

| 機能 | YamaPlayer | KawaPlayer |
|---|---|---|
| 動画再生 (YouTube / Twitch / HLS / 直リンク) | ✓ | ✓ (継承) |
| カラオケ / 区間リピート / 再生速度 / 最大解像度 | ✓ | ✓ (継承) |
| AudioLink / LTCGI / Light Volume 連携 | ✓ | ✓ (継承) |
| 多言語対応 (9 言語) | ✓ | ✓ (継承) |
| **外部プレイリスト URL の読込** (`playlist.vrc-hub.com`) | — | ✅ NEW |
| **ワールドのデフォルト URL を VRChat 内から設定** | — | ✅ NEW |
| **デフォルト URL の永続化** (再 join で自動復元) | — | ✅ NEW |

## 削除した実装詳細 (移行先候補)

以下の技術詳細は本 PR で README から削除。Fork 拡張者向けに `ARCHITECTURE.md` に切り出すかは別 issue で判断:

- `[UdonSynced] VRCUrl _defaultUrl` の Layer 1 同期機構
- `VRCPlayerObject + VRCEnablePersistence` による Layer 2 永続化機構
- `Pre-baked URL Pool + リダイレクトサーバー方式` (PlaylistLoader 内部実装)
- `Master が autoplay を起動` の責務制御

これらは引き続き `Modules/DefaultUrl/DefaultUrlController.cs` 等のソースコード + commit history (PR #56〜#61) で参照可能。

## Files Changed

| File | Change |
|---|---|
| `README.md` | +73 / -70 (構造再構成、内容は要約 + 並べ替えが主、Migration / License / Credits は維持) |

Net 変更: 116 行 → 118 行 (≈同等の長さで構造的可読性向上)

## What's NOT in this PR (将来別 issue 候補)

- `ARCHITECTURE.md` 切り出し (fork 拡張者向け技術参照)
- `README.en.md` (英語版、9 言語 user 層への対応)
- スクショ / GIF 追加 (動作デモ)

## Test plan

- [ ] GitHub 上で README プレビュー確認 (Markdown 文法 / リンク / 表 の表示)
- [ ] 既存リンク (upstream / vpm-repos URL / Releases ページ) が切れていないこと
- [ ] 内部リンク (`#yamaplayer-からの移行`, `#クイックスタート-vcc-推奨`) が機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
